### PR TITLE
add hold_entities_metadata to avoid metadata be broken

### DIFF
--- a/addons/ldtk-importer/ldtk-importer.gd
+++ b/addons/ldtk-importer/ldtk-importer.gd
@@ -75,6 +75,10 @@ func _get_import_options(path, index):
 		# --- Entities --- #
 		{"name": "Entity", "default_value":"", "usage": PROPERTY_USAGE_GROUP},
 		{
+			"name": "hold_entities_metadata",
+			"default_value": false,
+		},
+		{
 			"name": "use_entity_placeholders",
 			"default_value": false,
 		},

--- a/addons/ldtk-importer/src/util/field-util.gd
+++ b/addons/ldtk-importer/src/util/field-util.gd
@@ -10,6 +10,7 @@ static func create_fields(fields: Array, entity: Variant = null) -> Dictionary:
 	for field in fields:
 		var key: String = field.__identifier
 		dict[key] = parse_field(field)
+		if Util.options.hold_entities_metadata: continue
 		if hitUnresolved:
 			if dict[key] is Array:
 				for index in range(dict[key].size()):


### PR DESCRIPTION
This feature aim to save entity metadata when packing levels into single file.
In this condition entity ref info of metadata will be fill with null if ref missing, caz it's ref from full world scene.
For example, I want to parse all levels into single tscn file, and the entity ref will be process in world post stage. So that, the metadata of entities should as same as import.