### PR TITLE
enable customize resolve ref destination property

### DIFF
--- a/addons/ldtk-importer/src/util/util.gd
+++ b/addons/ldtk-importer/src/util/util.gd
@@ -104,8 +104,7 @@ static func add_tilemap_reference(uid: int, atlas: TileSetAtlasSource) -> void:
 
 # This is useful for handling entity instances, as they might not exist yet when encountered
 # or be overwritten at a later stage (e.g. post-import) when importing an LDTK level/world.
-static func add_unresolved_reference(object, property, node = object) -> void:
-	var iid: String = object[property]
+static func add_unresolved_reference(object, property, node = object, iid:String = object[property]) -> void:
 	unresolved_refs.append({
 			"object": object,
 			"property": property,


### PR DESCRIPTION
For resolve reference to custom property.
For example, I have a node, it has two fields `ref_id` and 'ref_data'.
'ref_id' is the source node identifier referenced by the node above, and 'ref_data' as the final data container.

Or destination node only has `ref_data` filed, this way I can pass `ref_id` manually.

```gdscript
var node = ... # has ref_data  and ref_id
var ref_data = ...
var iid = ...
entity_layer.add_child(node)
LDTKUtil.update_instance_reference(iid, ref_data)
if "SomeTraceld" in entity.fields:
    var ref_id = entity.fields.SomeTraceld
    if ref_id != null:
        LDTKUtil.add_unresolved_reference(node, "ref_data", stair, node.ref_id)
        # or LDTKUtil.add_unresolved_reference(node, "ref_data", stair, "My Custom Ref ID")
```