### PR TITLE
Fix `get_tileset_overrides()` Failure on External Levels

### DIFF
--- a/addons/ldtk-importer/ldtk-importer.gd
+++ b/addons/ldtk-importer/ldtk-importer.gd
@@ -175,6 +175,7 @@ func _import(
 
 	Util.timer_start(Util.DebugTime.LOAD)
 	var world_data := Util.parse_file(source_file)
+	var external_levels: bool = world_data.externalLevels
 	Util.timer_finish("File parsed")
 
 	# Check version
@@ -185,7 +186,7 @@ func _import(
 
 	Util.timer_start(Util.DebugTime.GENERAL)
 	var definitions := DefinitionUtil.build_definitions(world_data)
-	var tileset_overrides := Tileset.get_tileset_overrides(world_data)
+	var tileset_overrides := Tileset.get_tileset_overrides(world_data, base_dir, external_levels)
 	Util.timer_finish("Definitions Created")
 
 	# Build Tilesets and save as Resources
@@ -197,7 +198,6 @@ func _import(
 	Tileset.get_entity_def_tiles(definitions, Util.tilesets)
 
 	# Detect Multi-Worlds
-	var external_levels: bool = world_data.externalLevels
 	var world_iid: String = world_data.iid
 
 	var world: LDTKWorld

--- a/addons/ldtk-importer/src/tileset.gd
+++ b/addons/ldtk-importer/src/tileset.gd
@@ -315,9 +315,9 @@ static func get_entity_def_tiles(definitions: Dictionary, tilesets: Dictionary) 
 
 # Collect all layer tileset overrides. Later we'll ensure these sources are included in TileSet resources.
 static func get_tileset_overrides(
-	world_data: Dictionary,
-	base_dir: String,
-	external_levels: bool
+		world_data: Dictionary,
+		base_dir: String,
+		external_levels: bool
 ) -> Dictionary:
 	var overrides := {}
 	for level_index in range(world_data.levels.size()):

--- a/addons/ldtk-importer/src/tileset.gd
+++ b/addons/ldtk-importer/src/tileset.gd
@@ -2,6 +2,7 @@
 
 const Util = preload("util/util.gd")
 const TileUtil = preload("util/tile-util.gd")
+const LevelUtil = preload("util/level-util.gd")
 const FieldUtil = preload("util/field-util.gd")
 const PostImport = preload("post-import.gd")
 
@@ -313,10 +314,20 @@ static func get_entity_def_tiles(definitions: Dictionary, tilesets: Dictionary) 
 	return definitions
 
 # Collect all layer tileset overrides. Later we'll ensure these sources are included in TileSet resources.
-static func get_tileset_overrides(world_data: Dictionary) -> Dictionary:
+static func get_tileset_overrides(
+	world_data: Dictionary,
+	base_dir: String,
+	external_levels: bool
+) -> Dictionary:
 	var overrides := {}
-	for level in world_data.levels:
-		for layer in level.layerInstances:
+	for level_index in range(world_data.levels.size()):
+		var level_data
+		level_data = world_data.levels[level_index]
+
+		if external_levels:
+			level_data = LevelUtil.get_external_level(level_data, base_dir)
+
+		for layer in level_data.layerInstances:
 			if layer.overrideTilesetUid == null:
 				continue
 			var gridSize: int = layer.__gridSize


### PR DESCRIPTION
Resolves #45.

Changed signature for `get_tileset_overrides()` as suggested in the above issue. Please review the commit below for details.