### PR TITLE
Save Extension Options

### DIFF
--- a/addons/ldtk-importer/ldtk-importer.gd
+++ b/addons/ldtk-importer/ldtk-importer.gd
@@ -6,7 +6,7 @@ const LDTK_LATEST_VERSION = "1.5.3"
 enum Presets {DEFAULT}
 enum SaveExtensions {
 	SCN,
-	TSCN
+	TSCN,
 }
 
 const Util = preload("src/util/util.gd")

--- a/addons/ldtk-importer/ldtk-importer.gd
+++ b/addons/ldtk-importer/ldtk-importer.gd
@@ -3,7 +3,10 @@ extends EditorImportPlugin
 
 const LDTK_LATEST_VERSION = "1.5.3"
 
-enum Presets {DEFAULT}
+enum Presets {DEFAULT}enum SaveExtensions {
+	SCN,
+	TSCN
+}
 
 const Util = preload("src/util/util.gd")
 const World = preload("src/world.gd")
@@ -33,7 +36,7 @@ func _get_recognized_extensions():
 	return ["ldtk"]
 
 func _get_save_extension():
-	return "scn"
+	return SaveExtensions.keys()[Util.options.save_extension].to_lower()
 
 func _get_preset_count():
 	return Presets.size()
@@ -71,6 +74,12 @@ func _get_import_options(path, index):
 			# Save LDTKLevels as PackedScenes.
 			"name": "pack_levels",
 			"default_value": true,
+		},		{
+			# Define LDTKLevels save extension.
+			"name": "save_extension",
+			"default_value": 0,
+			"property_hint": PROPERTY_HINT_ENUM,
+			"hint_string": "scn,tscn",
 		},
 		# --- Layers --- #
 		{"name": "Layer", "default_value":"", "usage": PROPERTY_USAGE_GROUP},

--- a/addons/ldtk-importer/ldtk-importer.gd
+++ b/addons/ldtk-importer/ldtk-importer.gd
@@ -3,7 +3,8 @@ extends EditorImportPlugin
 
 const LDTK_LATEST_VERSION = "1.5.3"
 
-enum Presets {DEFAULT}enum SaveExtensions {
+enum Presets {DEFAULT}
+enum SaveExtensions {
 	SCN,
 	TSCN
 }

--- a/addons/ldtk-importer/ldtk-importer.gd
+++ b/addons/ldtk-importer/ldtk-importer.gd
@@ -4,9 +4,9 @@ extends EditorImportPlugin
 const LDTK_LATEST_VERSION = "1.5.3"
 
 enum Presets {DEFAULT}
-enum SaveExtensions {
+enum LevelSaveExtensions {
 	SCN,
-	TSCN,
+	TSCN
 }
 
 const Util = preload("src/util/util.gd")
@@ -37,7 +37,7 @@ func _get_recognized_extensions():
 	return ["ldtk"]
 
 func _get_save_extension():
-	return SaveExtensions.keys()[Util.options.save_extension].to_lower()
+	return LevelSaveExtensions.keys()[Util.options.level_save_extension].to_lower()
 
 func _get_preset_count():
 	return Presets.size()
@@ -75,9 +75,10 @@ func _get_import_options(path, index):
 			# Save LDTKLevels as PackedScenes.
 			"name": "pack_levels",
 			"default_value": true,
-		},		{
+		},
+		{
 			# Define LDTKLevels save extension.
-			"name": "save_extension",
+			"name": "level_save_extension",
 			"default_value": 0,
 			"property_hint": PROPERTY_HINT_ENUM,
 			"hint_string": "scn,tscn",
@@ -107,6 +108,13 @@ func _get_import_options(path, index):
 			"default_value": 0,
 			"property_hint": PROPERTY_HINT_ENUM,
 			"hint_string": "CompressedTexture2D,CanvasTexture",
+		},
+		{
+			# Define Godot tileset save extension.
+			"name": "tileset_save_extension",
+			"default_value": 0,
+			"property_hint": PROPERTY_HINT_ENUM,
+			"hint_string": "res,tres",
 		},
 		# --- Entities --- #
 		{"name": "Entity", "default_value":"", "usage": PROPERTY_USAGE_GROUP},

--- a/addons/ldtk-importer/src/tileset.gd
+++ b/addons/ldtk-importer/src/tileset.gd
@@ -2,10 +2,18 @@
 
 const Util = preload("util/util.gd")
 const TileUtil = preload("util/tile-util.gd")
+const LevelUtil = preload("util/level-util.gd")
 const FieldUtil = preload("util/field-util.gd")
 const PostImport = preload("post-import.gd")
 
 enum AtlasTextureType {CompressedTexture2D, CanvasTexture}
+enum TilesetSaveExtension {
+	RES,
+	TRES,
+}
+
+static func get_tileset_save_extension() -> String:
+	return TilesetSaveExtension.keys()[Util.options.tileset_save_extension].to_lower()
 
 static func build_tilesets(
 		definitions: Dictionary,
@@ -100,7 +108,11 @@ static func build_tilesets(
 
 static func get_tileset(tile_size: int,base_dir: String) -> TileSet:
 	var tileset_name := "tileset_%spx" % [str(tile_size)]
-	var path := base_dir + "tilesets/" + tileset_name + ".tres"
+	var path := "%stilesets/%s.%s" % [
+		base_dir,
+		tileset_name,
+		get_tileset_save_extension()
+	]
 
 	if not (Util.options.force_tileset_reimport):
 		if ResourceLoader.exists(path):
@@ -293,7 +305,7 @@ static func save_tilesets(tilesets: Dictionary, base_dir: String) -> Dictionary:
 			continue
 
 		var file_name = tileset.resource_name
-		var file_path = "%s%s.%s" % [save_path, file_name, "tres"]
+		var file_path = "%s%s.%s" % [save_path, file_name, get_tileset_save_extension()]
 		var err = ResourceSaver.save(tileset, file_path)
 		if err == OK:
 			gen_files[key] = file_path


### PR DESCRIPTION
I would like to add the `Import` option to specify the save extension for `LDTKLevel` files as either `scn` or `tscn`, and the save extension for tilesets as either `res` or `tres` (`scn` and `res` are the defaults to align with the old behavior):

![image](https://github.com/user-attachments/assets/c627a4ea-5f24-4cc5-b2ac-e596c5c67999)

This feature aims to provide the flexibility to version control the output of the plugin as either binary or text files, without having to write custom post-import script to export resources to `tscn`/`tres` format. This follows Godot's philosophy to generate VCS-friendly and human-readable files.

Thanks for your work on this plugin!